### PR TITLE
remove ?> from php files

### DIFF
--- a/pwnazon.php
+++ b/pwnazon.php
@@ -70,4 +70,3 @@ shell_exec("rm -r $adid ad-manifest.json");
     readfile($adfile);
     shell_exec("rm $adfile");
     exit;
-?>

--- a/pwnazon_extras/example.php.template
+++ b/pwnazon_extras/example.php.template
@@ -178,4 +178,3 @@ function create_advert($sourcefilename, $advertdirectory) {
         imagedestroy($image);
     }
 }
-?>


### PR DESCRIPTION
`?>` in php files is considered an anti-pattern. See the PSR-2 recommendation for reference:

http://www.php-fig.org/psr/psr-2/#2-2-files

Your final `exit()` statement can probably be safely omitted now, as the extra whitespace being sent out previously is gone.
